### PR TITLE
Quick fixes

### DIFF
--- a/hacks/media-on-gcp/artifacts/bootstrap.tf
+++ b/hacks/media-on-gcp/artifacts/bootstrap.tf
@@ -41,3 +41,9 @@ resource "google_project_iam_member" "centralized_project_binding" {
   role    = "roles/owner"
   member  = "serviceAccount:${var.host_centralized_serviceaccount_name}@${var.host_gcp_project_id}.iam.gserviceaccount.com"
 }
+
+resource "google_project_iam_member" "imageuser_role" {
+  project = var.host_gcp_project_id
+  role    = "roles/compute.imageUser"
+  member  = "serviceAccount:${local.project.number}@cloudservices.gserviceaccount.com"
+}

--- a/hacks/media-on-gcp/artifacts/bootstrap.tf
+++ b/hacks/media-on-gcp/artifacts/bootstrap.tf
@@ -1,0 +1,43 @@
+locals {
+  project = {
+    id     = var.gcp_project_id
+    name   = data.google_project.project.name
+    number = data.google_project.project.number
+  }
+  endpoint_url = "endpoints.${local.project.id}.cloud.goog"
+}
+
+data "google_project" "project" {
+  provider = google.bootstrap_user_account_googl
+
+  project_id = var.gcp_project_id
+}
+
+resource "google_project_service" "compute_api" {
+  provider = google.bootstrap_user_account_googl
+
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "vertexai_api" {
+  provider = google.bootstrap_user_account_googl
+
+  service            = "aiplatform.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "run_api" {
+  provider = google.bootstrap_user_account_googl
+
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_iam_member" "centralized_project_binding" {
+  provider = google.bootstrap_user_account_googl
+
+  project = local.project.id
+  role    = "roles/owner"
+  member  = "serviceAccount:${var.host_centralized_serviceaccount_name}@${var.host_gcp_project_id}.iam.gserviceaccount.com"
+}

--- a/hacks/media-on-gcp/artifacts/infra/stitcher/stable/main.tf
+++ b/hacks/media-on-gcp/artifacts/infra/stitcher/stable/main.tf
@@ -6,9 +6,9 @@ module "compute" {
   instance_group_name  = "stitch-machine-mig"
   base_instance_name   = "stitch-machine"
   target_size          = 1
-  machine_type         = "c4d-standard-2"
+  machine_type         = "n2d-standard-2"
   source_image         = "projects/media-on-gcp-storage/global/images/stitch-machine"
-  boot_disk_type       = "hyperdisk-balanced"
+  boot_disk_type       = "pd-standard"
   boot_disk_size       = 50
 
   networks             = var.networks

--- a/hacks/media-on-gcp/artifacts/infra/team-setup/README.md
+++ b/hacks/media-on-gcp/artifacts/infra/team-setup/README.md
@@ -1,0 +1,14 @@
+# Team Setup Terraform Module
+
+This module creates a set of Google Cloud Storage buckets for each team specified.
+
+## Usage
+
+```hcl
+module "team_setup" {
+  source      = "./infra/team-setup"
+  project_id  = var.gcp_project_id
+  teams       = ["alpha", "beta", "gamma"]
+  bucket_prefix = "my-team-buckets"
+}
+```

--- a/hacks/media-on-gcp/artifacts/infra/team-setup/main.tf
+++ b/hacks/media-on-gcp/artifacts/infra/team-setup/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+}
+
+resource "google_storage_bucket" "ad_creative" {
+  provider = google.bootstrap_user_account_googl
+
+  name          = "${var.gcp_project_id}-ad_creative"
+  location      = var.location
+  project       = var.gcp_project_id
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket" "hp_client" {
+  provider = google.bootstrap_user_account_googl
+
+  name          = "${var.gcp_project_id}-hp_client"
+  location      = var.location
+  project       = var.gcp_project_id
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+}
+
+resource "null_resource" "populate_hp_client" {
+  count = var.populate_hp_client_bucket ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "gcloud storage cp -r ${var.hp_client_artifacts_source_uri}/* gs://${google_storage_bucket.hp_client.name}/ --impersonate-service-account=${var.host_centralized_serviceaccount_name}"
+  }
+
+  depends_on = [google_storage_bucket.hp_client]
+}
+
+resource "google_storage_bucket_object" "team_folder" {
+  provider = google
+
+  bucket  = "ibc2025-ad-creative"
+  name    = "team-${var.gcp_project_id}/"
+  content = " "
+}

--- a/hacks/media-on-gcp/artifacts/infra/team-setup/outputs.tf
+++ b/hacks/media-on-gcp/artifacts/infra/team-setup/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_names" {
+  description = "The names of the created team buckets."
+  value = {
+    ad_creative = google_storage_bucket.ad_creative.name
+    hp_client   = google_storage_bucket.hp_client.name
+  }
+}

--- a/hacks/media-on-gcp/artifacts/infra/team-setup/variables.tf
+++ b/hacks/media-on-gcp/artifacts/infra/team-setup/variables.tf
@@ -1,0 +1,33 @@
+variable "gcp_project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "host_gcp_project_id" {
+  description = "The ID of the host project."
+  type        = string
+}
+
+variable "location" {
+  description = "The GCP region to deploy resources in."
+  type        = string
+  default     = "US"
+}
+
+variable "populate_hp_client_bucket" {
+  description = "If true, populates the hp_client bucket with artifacts from a remote source."
+  type        = bool
+  default     = false
+}
+
+variable "hp_client_artifacts_source_uri" {
+  description = "The URI of the remote bucket to source artifacts from for the hp_client bucket."
+  type        = string
+  default     = ""
+}
+
+variable "host_centralized_serviceaccount_name" {
+  description = "The name of the service account to impersonate for the copy operation."
+  type        = string
+  default     = ""
+}

--- a/hacks/media-on-gcp/artifacts/main.tf
+++ b/hacks/media-on-gcp/artifacts/main.tf
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_project_iam_member" "imageuser_role" {
-  project = var.host_gcp_project_id
-  role    = "roles/compute.imageUser"
-  member  = "serviceAccount:${local.project.number}@cloudservices.gserviceaccount.com"
-}
-
 module "ateme" {
   source = "./infra/ateme/stable"
 

--- a/hacks/media-on-gcp/artifacts/main.tf
+++ b/hacks/media-on-gcp/artifacts/main.tf
@@ -11,49 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-locals {
-  project = {
-    id     = var.gcp_project_id
-    name   = data.google_project.project.name
-    number = data.google_project.project.number
-  }
-  endpoint_url = "endpoints.${local.project.id}.cloud.goog"
-}
-
-data "google_project" "project" {
-  provider = google.bootstrap_user_account_googl
-
-  project_id = var.gcp_project_id
-}
-
-resource "google_project_service" "compute_api" {
-  provider = google.bootstrap_user_account_googl
-
-  service            = "compute.googleapis.com"
-  disable_on_destroy = false
-}
-
-resource "google_project_service" "vertexai_api" {
-  provider = google.bootstrap_user_account_googl
-
-  service            = "aiplatform.googleapis.com"
-  disable_on_destroy = false
-}
-
-resource "google_project_service" "run_api" {
-  provider = google.bootstrap_user_account_googl
-
-  service            = "run.googleapis.com"
-  disable_on_destroy = false
-}
-
-resource "google_project_iam_member" "centralized_project_binding" {
-  provider = google.bootstrap_user_account_googl
-
-  project = local.project.id
-  role    = "roles/owner"
-  member  = "serviceAccount:${var.host_centralized_serviceaccount_name}@${var.host_gcp_project_id}.iam.gserviceaccount.com"
-}
 
 resource "google_project_iam_member" "imageuser_role" {
   project = var.host_gcp_project_id
@@ -135,16 +92,32 @@ module "vizrt" {
   depends_on = [ google_project_iam_member.centralized_project_binding ]
 }
 
+module "team_setup" {
+  source = "./infra/team-setup"
+
+  providers = {
+    google                              = google
+    google.bootstrap_user_account_googl = google.bootstrap_user_account_googl
+  }
+
+  gcp_project_id      = local.project.id
+  host_gcp_project_id = var.host_gcp_project_id
+
+  host_centralized_serviceaccount_name = var.host_centralized_serviceaccount_name
+
+  depends_on = [google_project_iam_member.centralized_project_binding]
+}
+
 # TODO: Need stitcher image deployed and available
 
-# module "stitcher" {
-#   source = "./infra/stitcher/stable"
+module "stitcher" {
+  source = "./infra/stitcher/stable"
 
-#   project_id = local.project.id
-#   region     = var.gcp_region
-#   zone       = var.gcp_zone
+  project_id = local.project.id
+  region     = var.gcp_region
+  zone       = var.gcp_zone
 
-#   networks = [module.vpc.network_name]
+  networks = [module.vpc.network_name]
 
-#   depends_on = [ google_project_iam_member.centralized_project_binding ]
-# }
+  depends_on = [ google_project_iam_member.centralized_project_binding ]
+}

--- a/hacks/media-on-gcp/artifacts/net.tf
+++ b/hacks/media-on-gcp/artifacts/net.tf
@@ -26,7 +26,7 @@ module "gclb" {
       port                 = module.ateme.nea_named_ports[0].port # 8080
       port_name            = module.ateme.nea_named_ports[0].name # http1
       protocol             = "HTTP"
-      healthcheck_protocol = "tcp"
+      healthcheck_protocol = "http"
       enable_cdn           = false
     }
     cdn = {
@@ -34,7 +34,7 @@ module "gclb" {
       port                 = module.ateme.nea_named_ports[1].port # 80
       port_name            = module.ateme.nea_named_ports[1].name # http2
       protocol             = "HTTP"
-      healthcheck_protocol = "tcp"
+      healthcheck_protocol = "http"
       enable_cdn           = true
     }
     titan = {
@@ -42,7 +42,7 @@ module "gclb" {
       port                 = module.ateme.titan_named_ports[0].port # 443
       port_name            = module.ateme.titan_named_ports[0].name # https
       protocol             = "HTTPS"
-      healthcheck_protocol = "tcp"
+      healthcheck_protocol = "ssl"
       enable_cdn           = false
     }
     darwin = {
@@ -50,7 +50,7 @@ module "gclb" {
       port                 = module.darwin.darwin_named_ports[0].port # 443
       port_name            = module.darwin.darwin_named_ports[0].name # https
       protocol             = "HTTPS"
-      healthcheck_protocol = "tcp"
+      healthcheck_protocol = "ssl"
       enable_cdn           = false
     }
     "gemini" = {
@@ -58,7 +58,7 @@ module "gclb" {
       port                 = module.norsk_ai.named_ports[0].port # 443
       port_name            = module.norsk_ai.named_ports[0].name # https
       protocol             = "HTTPS"
-      healthcheck_protocol = "tcp"
+      healthcheck_protocol = "ssl"
       enable_cdn           = false
     }
     "norsk" = {
@@ -66,7 +66,7 @@ module "gclb" {
       port                 = module.norsk_gw.named_ports[0].port # 443
       port_name            = module.norsk_gw.named_ports[0].name # https
       protocol             = "HTTPS"
-      healthcheck_protocol = "tcp"
+      healthcheck_protocol = "ssl"
       enable_cdn           = false
     }
   }

--- a/hacks/media-on-gcp/artifacts/outputs.tf
+++ b/hacks/media-on-gcp/artifacts/outputs.tf
@@ -93,3 +93,8 @@ output "gclb_dns_address_norsk" {
   value       = module.gclb.endpoint_dns_addresses["norsk"]
 }
 
+output "team_bucket_names" {
+  description = "The names of the created team buckets."
+  value       = module.team_setup.bucket_names
+}
+


### PR DESCRIPTION
- organize bootstrap files into separate folder. Resources ran as bootstrap provider.
- enable stitch machine
- change healthchecks to http or ssl as needed
- create a bucket based on the student project id with two folders:
   - ad_creative - this is empty
   - hp_client - this holds the PCoIP client which you need to copy from another bucket. By default nothing is copied over
- Create folder object for `ibc2025-ad-creative` bucket in host project and create a team bucket 